### PR TITLE
Updated CDK version to 1.27.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,10 +24,10 @@
     }
   },
   "devDependencies": {
-    "@aws-cdk/assert": "1.26.0",
+    "@aws-cdk/assert": "1.27.0",
     "@types/jest": "^24.0.22",
     "@types/node": "10.17.5",
-    "aws-cdk": "1.26.0",
+    "aws-cdk": "1.27.0",
     "jest": "^24.9.0",
     "jsii": "0.21.1",
     "jsii-pacmak": "0.21.1",
@@ -39,22 +39,22 @@
     "source-map-support": "^0.5.16"
   },
   "dependencies": {
-    "@aws-cdk/aws-certificatemanager": "1.26.0",
-    "@aws-cdk/aws-cloudfront": "1.26.0",
-    "@aws-cdk/aws-route53-patterns": "1.26.0",
-    "@aws-cdk/aws-route53-targets": "1.26.0",
-    "@aws-cdk/aws-s3": "1.26.0",
-    "@aws-cdk/aws-s3-deployment": "1.26.0",
-    "@aws-cdk/core": "1.26.0"
+    "@aws-cdk/aws-certificatemanager": "1.27.0",
+    "@aws-cdk/aws-cloudfront": "1.27.0",
+    "@aws-cdk/aws-route53-patterns": "1.27.0",
+    "@aws-cdk/aws-route53-targets": "1.27.0",
+    "@aws-cdk/aws-s3": "1.27.0",
+    "@aws-cdk/aws-s3-deployment": "1.27.0",
+    "@aws-cdk/core": "1.27.0"
   },
   "peerDependencies": {
-    "@aws-cdk/aws-cloudfront": "1.26.0",
-    "@aws-cdk/aws-s3": "1.26.0",
-    "@aws-cdk/aws-s3-deployment": "1.26.0",
-    "@aws-cdk/aws-certificatemanager": "1.26.0",
-    "@aws-cdk/core": "1.26.0",
-    "@aws-cdk/aws-route53-patterns": "1.26.0",
-    "@aws-cdk/aws-route53-targets": "1.26.0"
+    "@aws-cdk/aws-cloudfront": "1.27.0",
+    "@aws-cdk/aws-s3": "1.27.0",
+    "@aws-cdk/aws-s3-deployment": "1.27.0",
+    "@aws-cdk/aws-certificatemanager": "1.27.0",
+    "@aws-cdk/core": "1.27.0",
+    "@aws-cdk/aws-route53-patterns": "1.27.0",
+    "@aws-cdk/aws-route53-targets": "1.27.0"
   },
   "keywords": [
     "aws",


### PR DESCRIPTION
Hey!

Thank you for this project! :)

I've noticed that after I started using it, I've had some issues after upgrading CDK to 1.27.0 (because apparently every construct version that you use in a CDK stack has to be exactly the same, otherwise there's a lot of issues).

This quick PR upgrades all `aws-cdk` packages to `1.27.0`