### PR TITLE
Allow the SPADeploy constructor to take in the error document cfg ite…

### DIFF
--- a/lib/spa-deploy/spa-deploy-construct.ts
+++ b/lib/spa-deploy/spa-deploy-construct.ts
@@ -10,6 +10,7 @@ import { CloudFrontTarget } from '@aws-cdk/aws-route53-targets';
 
 export interface SPADeployConfig {
   readonly indexDoc:string,
+  readonly errorDoc?:string,
   readonly websiteFolder: string,
   readonly certificateARN?: string,
   readonly cfAliases?: string[],
@@ -52,6 +53,7 @@ export class SPADeploy extends cdk.Construct {
       
       let bucketConfig:any = {
           websiteIndexDocument: config.indexDoc,
+          websiteErrorDocument: config.errorDoc,
           publicReadAccess: true
         };
         

--- a/test/cdk-spa-deploy.test.ts
+++ b/test/cdk-spa-deploy.test.ts
@@ -125,6 +125,40 @@ test('Basic Site Setup', () => {
     }));
 });
 
+test('Basic Site Setup with Error Doc set', () => {
+  let stack = new Stack();
+  
+  // WHEN
+  let deploy = new SPADeploy(stack, 'spaDeploy');
+  
+  deploy.createBasicSite({
+    indexDoc: 'index.html',
+    errorDoc: 'error.html',
+    websiteFolder: 'website'
+  })
+  
+  // THEN
+  expectCDK(stack).to(haveResource('AWS::S3::Bucket', {
+    WebsiteConfiguration: {
+      IndexDocument: 'index.html',
+      ErrorDocument: 'error.html'
+    }
+  }));
+  
+  expectCDK(stack).to(haveResource('Custom::CDKBucketDeployment'));
+  
+  expectCDK(stack).to(haveResourceLike('AWS::S3::BucketPolicy',  {
+          PolicyDocument: {
+              Statement: [
+                  {
+                      "Action": "s3:GetObject",
+                      "Effect": "Allow",
+                      "Principal": "*"
+                  }]
+          }
+  }));
+});
+
 test('Basic Site Setup, Encrypted Bucket', () => {
     let stack = new Stack();
     


### PR DESCRIPTION
…m for the S3 bucket.

Proposed fix/extension for the issue relating to react-router configs. - https://github.com/nideveloper/CDK-SPA-Deploy/issues/4 