### PR TITLE
Extend SPA-Deploy-From-Hosted-Zone with the ability to cfg S3 Error doc

### DIFF
--- a/lib/spa-deploy/spa-deploy-construct.ts
+++ b/lib/spa-deploy/spa-deploy-construct.ts
@@ -20,6 +20,7 @@ export interface SPADeployConfig {
 
 export interface HostedZoneConfig {
   readonly indexDoc:string,
+  readonly errorDoc?:string,
   readonly websiteFolder: string,
   readonly zoneName: string
 }

--- a/lib/spa-deploy/spa-deploy-construct.ts
+++ b/lib/spa-deploy/spa-deploy-construct.ts
@@ -103,12 +103,12 @@ export class SPADeploy extends cdk.Construct {
           //We need to redirect all unknown routes back to index.html for angular routing to work
           errorConfigurations: [{
             errorCode: 403,
-            responsePagePath: '/'+config.indexDoc,
+            responsePagePath: (config.errorDoc ? '/'+config.errorDoc : '/'+config.indexDoc),
             responseCode: 200
           },
           {
             errorCode: 404,
-            responsePagePath: '/'+config.indexDoc,
+            responsePagePath: (config.errorDoc ? '/'+config.errorDoc : '/'+config.indexDoc),
             responseCode: 200
           }]
         }


### PR DESCRIPTION
Apologies, I should have had this as part of the original extension for setting the s3 error doc with the basic site setup.  Hopefully that should do the trick now.