### PR TITLE
Grant CF Dist access to bucket via Access Identity & redundant ip filter for CF dists

### DIFF
--- a/.jsii
+++ b/.jsii
@@ -920,7 +920,7 @@
           },
           "locationInModule": {
             "filename": "lib/spa-deploy/spa-deploy-construct.ts",
-            "line": 150
+            "line": 137
           },
           "name": "createBasicSite",
           "parameters": [
@@ -938,7 +938,7 @@
           },
           "locationInModule": {
             "filename": "lib/spa-deploy/spa-deploy-construct.ts",
-            "line": 202
+            "line": 188
           },
           "name": "createSiteFromHostedZone",
           "parameters": [
@@ -956,7 +956,7 @@
           },
           "locationInModule": {
             "filename": "lib/spa-deploy/spa-deploy-construct.ts",
-            "line": 177
+            "line": 164
           },
           "name": "createSiteWithCloudfront",
           "parameters": [
@@ -1149,5 +1149,5 @@
     }
   },
   "version": "1.45.0",
-  "fingerprint": "PSzRMEw5fukWUYPT7Cp2K1M+4kxlz97S5zdAlAtPlI8="
+  "fingerprint": "lGOsiHwhXJqObFaD77a/1i9jPl4o/mWtcxYHGOJ+VNM="
 }

--- a/.jsii
+++ b/.jsii
@@ -6,13 +6,13 @@
     ]
   },
   "dependencies": {
-    "@aws-cdk/aws-certificatemanager": "1.36.0",
-    "@aws-cdk/aws-cloudfront": "1.36.0",
-    "@aws-cdk/aws-route53-patterns": "1.36.0",
-    "@aws-cdk/aws-route53-targets": "1.36.0",
-    "@aws-cdk/aws-s3": "1.36.0",
-    "@aws-cdk/aws-s3-deployment": "1.36.0",
-    "@aws-cdk/core": "1.36.0"
+    "@aws-cdk/aws-certificatemanager": "1.45.0",
+    "@aws-cdk/aws-cloudfront": "1.45.0",
+    "@aws-cdk/aws-route53-patterns": "1.45.0",
+    "@aws-cdk/aws-route53-targets": "1.45.0",
+    "@aws-cdk/aws-s3": "1.45.0",
+    "@aws-cdk/aws-s3-deployment": "1.45.0",
+    "@aws-cdk/core": "1.45.0"
   },
   "dependencyClosure": {
     "@aws-cdk/assets": {
@@ -615,6 +615,31 @@
         }
       }
     },
+    "@aws-cdk/cdk-assets-schema": {
+      "targets": {
+        "dotnet": {
+          "assemblyOriginatorKeyFile": "../../key.snk",
+          "iconUrl": "https://raw.githubusercontent.com/aws/aws-cdk/master/logo/default-256-dark.png",
+          "namespace": "Amazon.CDK.CdkAssets.Schema",
+          "packageId": "Amazon.CDK.CdkAssets.Schema",
+          "signAssembly": true
+        },
+        "java": {
+          "maven": {
+            "artifactId": "cdk-assets-schema",
+            "groupId": "software.amazon.awscdk"
+          },
+          "package": "software.amazon.awscdk.cdkassets.schema"
+        },
+        "js": {
+          "npm": "@aws-cdk/cdk-assets-schema"
+        },
+        "python": {
+          "distName": "aws-cdk.cdk-assets-schema",
+          "module": "aws_cdk.cdk_assets_schema"
+        }
+      }
+    },
     "@aws-cdk/cloud-assembly-schema": {
       "targets": {
         "dotnet": {
@@ -895,7 +920,7 @@
           },
           "locationInModule": {
             "filename": "lib/spa-deploy/spa-deploy-construct.ts",
-            "line": 135
+            "line": 150
           },
           "name": "createBasicSite",
           "parameters": [
@@ -913,7 +938,7 @@
           },
           "locationInModule": {
             "filename": "lib/spa-deploy/spa-deploy-construct.ts",
-            "line": 184
+            "line": 202
           },
           "name": "createSiteFromHostedZone",
           "parameters": [
@@ -931,7 +956,7 @@
           },
           "locationInModule": {
             "filename": "lib/spa-deploy/spa-deploy-construct.ts",
-            "line": 162
+            "line": 177
           },
           "name": "createSiteWithCloudfront",
           "parameters": [
@@ -1123,6 +1148,6 @@
       ]
     }
   },
-  "version": "1.36.0",
-  "fingerprint": "8X2QCHjkZbgCzOeIInfq8uzCTDTwHX6yeu1MgSV0wI8="
+  "version": "1.45.0",
+  "fingerprint": "PSzRMEw5fukWUYPT7Cp2K1M+4kxlz97S5zdAlAtPlI8="
 }

--- a/lib/spa-deploy/spa-deploy-construct.ts
+++ b/lib/spa-deploy/spa-deploy-construct.ts
@@ -96,7 +96,7 @@ export class SPADeploy extends cdk.Construct {
             {
               s3OriginSource: {
                 s3BucketSource: websiteBucket,
-                accessIdentity: accessIdentity
+                originAccessIdentity: accessIdentity
               },
               behaviors : [ {isDefaultBehavior: true}]
             }

--- a/lib/spa-deploy/spa-deploy-construct.ts
+++ b/lib/spa-deploy/spa-deploy-construct.ts
@@ -130,19 +130,6 @@ export class SPADeploy extends cdk.Construct {
         return cfConfig;
     }
     
-    /**
-     * This will grant a provided OriginAccessIdentity access to read objects from the bucket. This allows for the bucket to have public access disabled
-     * 
-     * See: https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-restricting-access-to-s3.html
-     */
-    private grantIdentityAccessToBucket(bucket: s3.Bucket, accessIdentity: OriginAccessIdentity) {
-      const bucketPolicy = new PolicyStatement();
-      bucketPolicy.addPrincipals(accessIdentity.grantPrincipal);
-      bucketPolicy.addActions('s3:GetObject');
-      bucketPolicy.addResources(bucket.bucketArn + '/*');
-      bucket.addToResourcePolicy(bucketPolicy);
-    }
-
 
     /**
      * Basic setup needed for a non-ssl, non vanity url, non cached s3 website
@@ -178,7 +165,6 @@ export class SPADeploy extends cdk.Construct {
         const websiteBucket = this.getS3Bucket(config, true);
         const accessIdentity = new OriginAccessIdentity(this, 'OriginAccessIdentity', {comment: `${websiteBucket.bucketName}-access-identity`});
         const distribution = new CloudFrontWebDistribution(this, 'cloudfrontDistribution', this.getCFConfig(websiteBucket, config, accessIdentity));
-        this.grantIdentityAccessToBucket(websiteBucket, accessIdentity);
 
         new s3deploy.BucketDeployment(this, 'BucketDeployment', {
           sources: [s3deploy.Source.asset(config.websiteFolder)], 
@@ -211,7 +197,6 @@ export class SPADeploy extends cdk.Construct {
             
         const accessIdentity = new OriginAccessIdentity(this, 'OriginAccessIdentity', {comment: `${websiteBucket.bucketName}-access-identity`});
         const distribution = new CloudFrontWebDistribution(this, 'cloudfrontDistribution', this.getCFConfig(websiteBucket, config, accessIdentity, cert));
-        this.grantIdentityAccessToBucket(websiteBucket, accessIdentity);
         
         new s3deploy.BucketDeployment(this, 'BucketDeployment', {
           sources: [s3deploy.Source.asset(config.websiteFolder)], 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,29 +1,411 @@
 {
   "name": "cdk-spa-deploy",
-  "version": "1.36.0",
+  "version": "1.45.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@aws-cdk/assert": {
-      "version": "1.36.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/assert/-/assert-1.36.0.tgz",
-      "integrity": "sha512-0nF4QZM08vYsWoHiVYEAGNxjDXVpq0ghUIoBCNKPy7t92umvw027672e8LQTijbAnqbHuCmJKDwwmsEraqh7NA==",
+      "version": "1.45.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/assert/-/assert-1.45.0.tgz",
+      "integrity": "sha512-djZKkqkJklwIUUV37CeALNqaRHSTmEmomnb8cDaqH15smET7Upi5mbtXOQJpNHRblpiBUWkg1dkzm7yf8lpSjg==",
       "dev": true,
       "requires": {
-        "@aws-cdk/cloud-assembly-schema": "1.36.0",
-        "@aws-cdk/cloudformation-diff": "1.36.0",
-        "@aws-cdk/core": "1.36.0",
-        "@aws-cdk/cx-api": "1.36.0",
+        "@aws-cdk/cloud-assembly-schema": "1.45.0",
+        "@aws-cdk/cloudformation-diff": "1.45.0",
+        "@aws-cdk/core": "1.45.0",
+        "@aws-cdk/cx-api": "1.45.0",
         "constructs": "^3.0.2"
       }
     },
     "@aws-cdk/assets": {
-      "version": "1.36.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/assets/-/assets-1.36.0.tgz",
-      "integrity": "sha512-dgHD9Yw46qNyl1NzYAdRv6VUj8zbC6GothZdEy0x6p+LnNlweGG/o4UXhaIanWItMKIAocQROXajUqM8B4aFPg==",
+      "version": "1.45.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/assets/-/assets-1.45.0.tgz",
+      "integrity": "sha512-VcW90IszJGd95RascHmFzcBGVfuMTuVIq1qiP0tHwX35xdxQydeZC5lT5No1bnTW9zATgrzbYAP9WAASkeMQ6A==",
       "requires": {
-        "@aws-cdk/core": "1.36.0",
-        "@aws-cdk/cx-api": "1.36.0",
+        "@aws-cdk/core": "1.45.0",
+        "@aws-cdk/cx-api": "1.45.0",
+        "constructs": "^3.0.2"
+      }
+    },
+    "@aws-cdk/aws-apigateway": {
+      "version": "1.45.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-apigateway/-/aws-apigateway-1.45.0.tgz",
+      "integrity": "sha512-7RPWccLjO/cla3VqiNBA6u6kWwhsZaOx94RZTIvcRfkGOOMbF7jeYT8sJu9kXrAPwVq0l4Nn7SBs7Dc6HrgJSA==",
+      "requires": {
+        "@aws-cdk/assets": "1.45.0",
+        "@aws-cdk/aws-certificatemanager": "1.45.0",
+        "@aws-cdk/aws-ec2": "1.45.0",
+        "@aws-cdk/aws-elasticloadbalancingv2": "1.45.0",
+        "@aws-cdk/aws-iam": "1.45.0",
+        "@aws-cdk/aws-lambda": "1.45.0",
+        "@aws-cdk/aws-logs": "1.45.0",
+        "@aws-cdk/aws-s3": "1.45.0",
+        "@aws-cdk/aws-s3-assets": "1.45.0",
+        "@aws-cdk/core": "1.45.0",
+        "@aws-cdk/cx-api": "1.45.0",
+        "constructs": "^3.0.2"
+      }
+    },
+    "@aws-cdk/aws-certificatemanager": {
+      "version": "1.45.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-certificatemanager/-/aws-certificatemanager-1.45.0.tgz",
+      "integrity": "sha512-30UHxkB3bQ+wBeNbf+bPdvxr9S89eKqz5ojMDkOY+MbXW040vQ7w1c12ed6C8dajVzxv9KO3FBbciROA3KsEWA==",
+      "requires": {
+        "@aws-cdk/aws-iam": "1.45.0",
+        "@aws-cdk/aws-lambda": "1.45.0",
+        "@aws-cdk/aws-route53": "1.45.0",
+        "@aws-cdk/core": "1.45.0",
+        "constructs": "^3.0.2"
+      }
+    },
+    "@aws-cdk/aws-cloudformation": {
+      "version": "1.45.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cloudformation/-/aws-cloudformation-1.45.0.tgz",
+      "integrity": "sha512-HchkjqvulM9Qmb5XDMRvxM3+UJih1lYpP4ti+KrsEu3WZ8Bvd6O8GJfcUOHPX8xgYHWC4cpJyRX8DJx6gcjsxQ==",
+      "requires": {
+        "@aws-cdk/aws-iam": "1.45.0",
+        "@aws-cdk/aws-lambda": "1.45.0",
+        "@aws-cdk/aws-s3": "1.45.0",
+        "@aws-cdk/aws-sns": "1.45.0",
+        "@aws-cdk/core": "1.45.0",
+        "@aws-cdk/cx-api": "1.45.0",
+        "constructs": "^3.0.2"
+      }
+    },
+    "@aws-cdk/aws-cloudfront": {
+      "version": "1.45.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cloudfront/-/aws-cloudfront-1.45.0.tgz",
+      "integrity": "sha512-cLJdDWO4CZjl/Tg7hcOxPZj6EMj/9OPNZqe5a+YGhhZu9GImTuvs9N6Ip64MvKuC5M/M7WT0QEJeRA3lxvAF3Q==",
+      "requires": {
+        "@aws-cdk/aws-certificatemanager": "1.45.0",
+        "@aws-cdk/aws-iam": "1.45.0",
+        "@aws-cdk/aws-kms": "1.45.0",
+        "@aws-cdk/aws-lambda": "1.45.0",
+        "@aws-cdk/aws-s3": "1.45.0",
+        "@aws-cdk/core": "1.45.0",
+        "constructs": "^3.0.2"
+      }
+    },
+    "@aws-cdk/aws-cloudwatch": {
+      "version": "1.45.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cloudwatch/-/aws-cloudwatch-1.45.0.tgz",
+      "integrity": "sha512-muV1hRUG2WDYiNNsVjrf8shq9+PYDmkNU/CZzMu2tNE7fzAbMO4s7dQjVxooJy3r0PvxmeOu/OSJGOtHu71PWw==",
+      "requires": {
+        "@aws-cdk/aws-iam": "1.45.0",
+        "@aws-cdk/core": "1.45.0",
+        "constructs": "^3.0.2"
+      }
+    },
+    "@aws-cdk/aws-cognito": {
+      "version": "1.45.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cognito/-/aws-cognito-1.45.0.tgz",
+      "integrity": "sha512-SYAis/bVoW7wem90EB7c5Nic8IGvCh12LvNN+oP5Vx+YR+1h2ksjnsvg0Tr2Xl8CS8yw7HmnkkqNJKkHm1V0Uw==",
+      "requires": {
+        "@aws-cdk/aws-certificatemanager": "1.45.0",
+        "@aws-cdk/aws-iam": "1.45.0",
+        "@aws-cdk/aws-lambda": "1.45.0",
+        "@aws-cdk/core": "1.45.0",
+        "@aws-cdk/custom-resources": "1.45.0",
+        "constructs": "^3.0.2"
+      }
+    },
+    "@aws-cdk/aws-ec2": {
+      "version": "1.45.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ec2/-/aws-ec2-1.45.0.tgz",
+      "integrity": "sha512-QOMQ4RwFhN+OADY+W36fCs719dSS5AWWg2KZpnJlIuhjTz9eRgzGrwh17BzqtLs/C7RLP7hYS1Jijqk/Tx4sfA==",
+      "requires": {
+        "@aws-cdk/aws-cloudwatch": "1.45.0",
+        "@aws-cdk/aws-iam": "1.45.0",
+        "@aws-cdk/aws-logs": "1.45.0",
+        "@aws-cdk/aws-s3": "1.45.0",
+        "@aws-cdk/aws-ssm": "1.45.0",
+        "@aws-cdk/cloud-assembly-schema": "1.45.0",
+        "@aws-cdk/core": "1.45.0",
+        "@aws-cdk/cx-api": "1.45.0",
+        "@aws-cdk/region-info": "1.45.0",
+        "constructs": "^3.0.2"
+      }
+    },
+    "@aws-cdk/aws-elasticloadbalancing": {
+      "version": "1.45.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-elasticloadbalancing/-/aws-elasticloadbalancing-1.45.0.tgz",
+      "integrity": "sha512-CRej4Jb4a7HeQt7x/yKgq6KT6XszBl9zv4M+SuAirlLMaeUpb36ykBUlyyTNuajyOnEBXkUZUKCH/1+vXvFWXA==",
+      "requires": {
+        "@aws-cdk/aws-ec2": "1.45.0",
+        "@aws-cdk/core": "1.45.0",
+        "constructs": "^3.0.2"
+      }
+    },
+    "@aws-cdk/aws-elasticloadbalancingv2": {
+      "version": "1.45.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-elasticloadbalancingv2/-/aws-elasticloadbalancingv2-1.45.0.tgz",
+      "integrity": "sha512-jAh7baa0c+oYvXhZMnCsrgis7tKAOBTOJReiFnYyDjY2Ol5l6mxz4jDQKCoV7gnW79fX3kWGmGmIIu0pHr5XXA==",
+      "requires": {
+        "@aws-cdk/aws-certificatemanager": "1.45.0",
+        "@aws-cdk/aws-cloudwatch": "1.45.0",
+        "@aws-cdk/aws-ec2": "1.45.0",
+        "@aws-cdk/aws-iam": "1.45.0",
+        "@aws-cdk/aws-lambda": "1.45.0",
+        "@aws-cdk/aws-s3": "1.45.0",
+        "@aws-cdk/core": "1.45.0",
+        "constructs": "^3.0.2"
+      }
+    },
+    "@aws-cdk/aws-events": {
+      "version": "1.45.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-events/-/aws-events-1.45.0.tgz",
+      "integrity": "sha512-OexoSgVmqQw23rd/ULZ0lGVqYm69Rx15vsV7UXBg3T5uPmonZKoIdfufqzUG1LU0YiuAIlpmJEgrvqkkllDcqw==",
+      "requires": {
+        "@aws-cdk/aws-iam": "1.45.0",
+        "@aws-cdk/core": "1.45.0",
+        "constructs": "^3.0.2"
+      }
+    },
+    "@aws-cdk/aws-iam": {
+      "version": "1.45.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-iam/-/aws-iam-1.45.0.tgz",
+      "integrity": "sha512-Ngdl2x9YxRQ2zRzWW+Y7Xu/iEVKeMc3MXYGKuWijw7VDBae6rp4r51pch9Gli+ONpCpZL1+Jw8lsPo5VNJuBLQ==",
+      "requires": {
+        "@aws-cdk/core": "1.45.0",
+        "@aws-cdk/region-info": "1.45.0",
+        "constructs": "^3.0.2"
+      }
+    },
+    "@aws-cdk/aws-kms": {
+      "version": "1.45.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-kms/-/aws-kms-1.45.0.tgz",
+      "integrity": "sha512-WPR0CkKtAU6szhWUTuu+LUmElDDbOqTbHNF+wgk1W6rq1wxHfyn3kW7AM4Dv/fF6VRRotryyDqsbANIqYnkTtA==",
+      "requires": {
+        "@aws-cdk/aws-iam": "1.45.0",
+        "@aws-cdk/core": "1.45.0",
+        "constructs": "^3.0.2"
+      }
+    },
+    "@aws-cdk/aws-lambda": {
+      "version": "1.45.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-lambda/-/aws-lambda-1.45.0.tgz",
+      "integrity": "sha512-rXqxc8rac3UhZbJ101KvKbZ2JWsjaOYewFXO876rTdckCgq4A2DpH4qFmgFj0Ev/aoi3821m8F9WdY5vEinh8Q==",
+      "requires": {
+        "@aws-cdk/aws-cloudwatch": "1.45.0",
+        "@aws-cdk/aws-ec2": "1.45.0",
+        "@aws-cdk/aws-events": "1.45.0",
+        "@aws-cdk/aws-iam": "1.45.0",
+        "@aws-cdk/aws-logs": "1.45.0",
+        "@aws-cdk/aws-s3": "1.45.0",
+        "@aws-cdk/aws-s3-assets": "1.45.0",
+        "@aws-cdk/aws-sqs": "1.45.0",
+        "@aws-cdk/core": "1.45.0",
+        "@aws-cdk/cx-api": "1.45.0",
+        "constructs": "^3.0.2"
+      }
+    },
+    "@aws-cdk/aws-logs": {
+      "version": "1.45.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-logs/-/aws-logs-1.45.0.tgz",
+      "integrity": "sha512-zktaysJXripb0sgbJXlRH9cdZdTCoRZbQU5raKMFKq+w+fr7Tpor0aslNKXVLEppoX6udbqLAevdSk63IkIFSw==",
+      "requires": {
+        "@aws-cdk/aws-cloudwatch": "1.45.0",
+        "@aws-cdk/aws-iam": "1.45.0",
+        "@aws-cdk/core": "1.45.0",
+        "constructs": "^3.0.2"
+      }
+    },
+    "@aws-cdk/aws-route53": {
+      "version": "1.45.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-route53/-/aws-route53-1.45.0.tgz",
+      "integrity": "sha512-XUxg0LvPXz/a13aCkc8RBDmsOwYp2XZ+bPOKNDENoni0Sw+2DqPdk1FOqgf3diF/hJxtw+ck3h8tcIgcNoe7nw==",
+      "requires": {
+        "@aws-cdk/aws-ec2": "1.45.0",
+        "@aws-cdk/aws-logs": "1.45.0",
+        "@aws-cdk/cloud-assembly-schema": "1.45.0",
+        "@aws-cdk/core": "1.45.0",
+        "constructs": "^3.0.2"
+      }
+    },
+    "@aws-cdk/aws-route53-patterns": {
+      "version": "1.45.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-route53-patterns/-/aws-route53-patterns-1.45.0.tgz",
+      "integrity": "sha512-nTCJwnOjx6/Ocp++7cAqd/vOcBsKQk6wmtuVVT+HmAfXPlYC8R0qrGo/fOPcDtejrROGbieJosu/FEzEpf1bAA==",
+      "requires": {
+        "@aws-cdk/aws-certificatemanager": "1.45.0",
+        "@aws-cdk/aws-cloudfront": "1.45.0",
+        "@aws-cdk/aws-iam": "1.45.0",
+        "@aws-cdk/aws-route53": "1.45.0",
+        "@aws-cdk/aws-route53-targets": "1.45.0",
+        "@aws-cdk/aws-s3": "1.45.0",
+        "@aws-cdk/core": "1.45.0",
+        "@aws-cdk/region-info": "1.45.0",
+        "constructs": "^3.0.2"
+      }
+    },
+    "@aws-cdk/aws-route53-targets": {
+      "version": "1.45.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-route53-targets/-/aws-route53-targets-1.45.0.tgz",
+      "integrity": "sha512-Slp0b+Vi10XC6MPQcIWSRzy1MbmhFcLVbPFLdGA921NPODZs1i/tXPEsmlbBw47FO/gSa/CSxvkPSo/FNmkQvQ==",
+      "requires": {
+        "@aws-cdk/aws-apigateway": "1.45.0",
+        "@aws-cdk/aws-cloudfront": "1.45.0",
+        "@aws-cdk/aws-cognito": "1.45.0",
+        "@aws-cdk/aws-ec2": "1.45.0",
+        "@aws-cdk/aws-elasticloadbalancing": "1.45.0",
+        "@aws-cdk/aws-elasticloadbalancingv2": "1.45.0",
+        "@aws-cdk/aws-iam": "1.45.0",
+        "@aws-cdk/aws-route53": "1.45.0",
+        "@aws-cdk/aws-s3": "1.45.0",
+        "@aws-cdk/core": "1.45.0",
+        "@aws-cdk/region-info": "1.45.0",
+        "constructs": "^3.0.2"
+      }
+    },
+    "@aws-cdk/aws-s3": {
+      "version": "1.45.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-s3/-/aws-s3-1.45.0.tgz",
+      "integrity": "sha512-8FIt83/Jy08fG/ygtUVRYj0m3xrc6PUKndcLW4ysf+HL+tb7OX0AMPTx3jRKLJwS6VoWGXc0zcKMBrNWUSsglA==",
+      "requires": {
+        "@aws-cdk/aws-events": "1.45.0",
+        "@aws-cdk/aws-iam": "1.45.0",
+        "@aws-cdk/aws-kms": "1.45.0",
+        "@aws-cdk/core": "1.45.0",
+        "constructs": "^3.0.2"
+      }
+    },
+    "@aws-cdk/aws-s3-assets": {
+      "version": "1.45.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-s3-assets/-/aws-s3-assets-1.45.0.tgz",
+      "integrity": "sha512-ld3c7MSd0M1nofPLclRjm0oGtU136VFOuUK4KYQ75j7Nomg1Xjt9MKdqhJODhAC4Xmg4+8eiac1TC1w8aljTGg==",
+      "requires": {
+        "@aws-cdk/assets": "1.45.0",
+        "@aws-cdk/aws-iam": "1.45.0",
+        "@aws-cdk/aws-s3": "1.45.0",
+        "@aws-cdk/core": "1.45.0",
+        "@aws-cdk/cx-api": "1.45.0",
+        "constructs": "^3.0.2"
+      }
+    },
+    "@aws-cdk/aws-s3-deployment": {
+      "version": "1.45.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-s3-deployment/-/aws-s3-deployment-1.45.0.tgz",
+      "integrity": "sha512-VueCl9QOkukTxahIjMMIooUH3mkX3vb0/ceQfnubA7jrKzws/r6jPnlbPuE3SHeBuUmB36oVwlM2Q9B8sCtuxA==",
+      "requires": {
+        "@aws-cdk/aws-cloudfront": "1.45.0",
+        "@aws-cdk/aws-iam": "1.45.0",
+        "@aws-cdk/aws-lambda": "1.45.0",
+        "@aws-cdk/aws-s3": "1.45.0",
+        "@aws-cdk/aws-s3-assets": "1.45.0",
+        "@aws-cdk/core": "1.45.0",
+        "constructs": "^3.0.2"
+      }
+    },
+    "@aws-cdk/aws-sns": {
+      "version": "1.45.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-sns/-/aws-sns-1.45.0.tgz",
+      "integrity": "sha512-OKsVGSdmTQtWWkXFCUEs080LnL63Ea8cqOOyTpTQEiYqxSDvlQUKPaNKwO8nz9xaI+CF64zlrjed8ud8Lg1sGw==",
+      "requires": {
+        "@aws-cdk/aws-cloudwatch": "1.45.0",
+        "@aws-cdk/aws-events": "1.45.0",
+        "@aws-cdk/aws-iam": "1.45.0",
+        "@aws-cdk/aws-kms": "1.45.0",
+        "@aws-cdk/aws-sqs": "1.45.0",
+        "@aws-cdk/core": "1.45.0",
+        "constructs": "^3.0.2"
+      }
+    },
+    "@aws-cdk/aws-sqs": {
+      "version": "1.45.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-sqs/-/aws-sqs-1.45.0.tgz",
+      "integrity": "sha512-klMLsG+aZzUibcmKTAmOgzKnEdIderrEsmvgLW15bnNrtBeCI5xbHQ/sISlPLL1wvp0YZ8kunDndP8JjQnQXBA==",
+      "requires": {
+        "@aws-cdk/aws-cloudwatch": "1.45.0",
+        "@aws-cdk/aws-iam": "1.45.0",
+        "@aws-cdk/aws-kms": "1.45.0",
+        "@aws-cdk/core": "1.45.0",
+        "constructs": "^3.0.2"
+      }
+    },
+    "@aws-cdk/aws-ssm": {
+      "version": "1.45.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ssm/-/aws-ssm-1.45.0.tgz",
+      "integrity": "sha512-MqHvPATnpz8XpG/s0Q9SZQJP0Jji03ZeYvfqJO6PsuqTNLNJCMAWP5tJy2t/CxqxSFBI9JlAquj2+0Gyqwqgbg==",
+      "requires": {
+        "@aws-cdk/aws-iam": "1.45.0",
+        "@aws-cdk/aws-kms": "1.45.0",
+        "@aws-cdk/cloud-assembly-schema": "1.45.0",
+        "@aws-cdk/core": "1.45.0",
+        "constructs": "^3.0.2"
+      }
+    },
+    "@aws-cdk/cdk-assets-schema": {
+      "version": "1.45.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cdk-assets-schema/-/cdk-assets-schema-1.45.0.tgz",
+      "integrity": "sha512-HvS9IN0RTIwJvldOLj/0FsWSj1h3jqeT9sfNdAW0g7FeFSPu3QtdYeDcSGrOo/4fPXsRFV4bcMqoEEph3x9MgQ==",
+      "requires": {
+        "semver": "^7.2.2"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "7.3.2",
+          "bundled": true
+        }
+      }
+    },
+    "@aws-cdk/cfnspec": {
+      "version": "1.45.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cfnspec/-/cfnspec-1.45.0.tgz",
+      "integrity": "sha512-Ps4P+e9xbqJkmlyREESN18jBUPixvaCdAyw6eNvfmQGQudFkggm05jiKMulLu/trzTdRuD8NBPE7pxZPgoOvIg==",
+      "dev": true,
+      "requires": {
+        "md5": "^2.2.1"
+      }
+    },
+    "@aws-cdk/cloud-assembly-schema": {
+      "version": "1.45.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-1.45.0.tgz",
+      "integrity": "sha512-MoQ8580BJYDKzWHNPbn/WiB82A1JdZJXkZ/W0mwR6mi37DOJ6jbycyhGXA9aARw5iNIxqTEAXqGifrUI1ILG+w==",
+      "requires": {
+        "jsonschema": "^1.2.5",
+        "semver": "^7.2.2"
+      },
+      "dependencies": {
+        "jsonschema": {
+          "version": "1.2.6",
+          "bundled": true
+        },
+        "semver": {
+          "version": "7.3.2",
+          "bundled": true
+        }
+      }
+    },
+    "@aws-cdk/cloudformation-diff": {
+      "version": "1.45.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloudformation-diff/-/cloudformation-diff-1.45.0.tgz",
+      "integrity": "sha512-/5djWhNdhoLz+zFDa8ALd83hqxu0KLKaDVp3NQvVF5FAS7GTrR4UlsSrOllI5DqWafF1pCIgM6LXGF95LoMmbg==",
+      "dev": true,
+      "requires": {
+        "@aws-cdk/cfnspec": "1.45.0",
+        "colors": "^1.4.0",
+        "diff": "^4.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "string-width": "^4.2.0",
+        "table": "^5.4.6"
+      },
+      "dependencies": {
+        "diff": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+          "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+          "dev": true
+        }
+      }
+    },
+    "@aws-cdk/core": {
+      "version": "1.45.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/core/-/core-1.45.0.tgz",
+      "integrity": "sha512-XsUlW5OJi/gRfPbRQp/ps8uqUX6a8KIKXFHbl8sYVoiUWRYOwZq58ffO5EhGL841vZb21xRbgysSfURbWLSlUA==",
+      "requires": {
+        "@aws-cdk/cdk-assets-schema": "1.45.0",
+        "@aws-cdk/cloud-assembly-schema": "1.45.0",
+        "@aws-cdk/cx-api": "1.45.0",
         "constructs": "^3.0.2",
         "minimatch": "^3.0.4"
       },
@@ -53,389 +435,26 @@
         }
       }
     },
-    "@aws-cdk/aws-apigateway": {
-      "version": "1.36.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-apigateway/-/aws-apigateway-1.36.0.tgz",
-      "integrity": "sha512-dDioh6r1crpH1pZUsLYatKsIlRfxUaRGo3qKeAZx0TMmoptCTNDo07/KxP3DD/J0q7syl3J8V4CZ4UnFYSasyg==",
-      "requires": {
-        "@aws-cdk/aws-certificatemanager": "1.36.0",
-        "@aws-cdk/aws-ec2": "1.36.0",
-        "@aws-cdk/aws-elasticloadbalancingv2": "1.36.0",
-        "@aws-cdk/aws-iam": "1.36.0",
-        "@aws-cdk/aws-lambda": "1.36.0",
-        "@aws-cdk/aws-logs": "1.36.0",
-        "@aws-cdk/core": "1.36.0",
-        "constructs": "^3.0.2"
-      }
-    },
-    "@aws-cdk/aws-certificatemanager": {
-      "version": "1.36.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-certificatemanager/-/aws-certificatemanager-1.36.0.tgz",
-      "integrity": "sha512-J1mv0/PGe3uKx4yW8PNSYkPXrzAA9Zkfo7K8QyQq/fraUQ3VPXa0qlP9HuTHlo/bfUOKsTe4MTdFMtjOWLRqUQ==",
-      "requires": {
-        "@aws-cdk/aws-cloudformation": "1.36.0",
-        "@aws-cdk/aws-iam": "1.36.0",
-        "@aws-cdk/aws-lambda": "1.36.0",
-        "@aws-cdk/aws-route53": "1.36.0",
-        "@aws-cdk/core": "1.36.0",
-        "constructs": "^3.0.2"
-      }
-    },
-    "@aws-cdk/aws-cloudformation": {
-      "version": "1.36.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cloudformation/-/aws-cloudformation-1.36.0.tgz",
-      "integrity": "sha512-f3VuKXq9EpAp8P3TQlRCpZa42QyBnZaAghdsgF1QoQQm+n8OlLwo036DQrX8PU3Q9DEM8Cr26VFpLiNQAPQe1Q==",
-      "requires": {
-        "@aws-cdk/aws-iam": "1.36.0",
-        "@aws-cdk/aws-lambda": "1.36.0",
-        "@aws-cdk/aws-s3": "1.36.0",
-        "@aws-cdk/aws-sns": "1.36.0",
-        "@aws-cdk/core": "1.36.0",
-        "@aws-cdk/cx-api": "1.36.0",
-        "constructs": "^3.0.2"
-      }
-    },
-    "@aws-cdk/aws-cloudfront": {
-      "version": "1.36.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cloudfront/-/aws-cloudfront-1.36.0.tgz",
-      "integrity": "sha512-oS3Re7YYVN23Q2AaTuDiuW/NZTZoGDQeH2PN3oq1vxZDGd69OU3fwJwkYp6RwkTjm+1FMy4MSrz7SKd31aPA3Q==",
-      "requires": {
-        "@aws-cdk/aws-certificatemanager": "1.36.0",
-        "@aws-cdk/aws-iam": "1.36.0",
-        "@aws-cdk/aws-kms": "1.36.0",
-        "@aws-cdk/aws-lambda": "1.36.0",
-        "@aws-cdk/aws-s3": "1.36.0",
-        "@aws-cdk/core": "1.36.0",
-        "constructs": "^3.0.2"
-      }
-    },
-    "@aws-cdk/aws-cloudwatch": {
-      "version": "1.36.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cloudwatch/-/aws-cloudwatch-1.36.0.tgz",
-      "integrity": "sha512-P4GqHSUJHea79dym8ih/oazFCG7GPCoFTqULXbFF3KpD68feZZqfs3YULSQO1c14HYuP6HtKyWYarlXZk15AEA==",
-      "requires": {
-        "@aws-cdk/aws-iam": "1.36.0",
-        "@aws-cdk/core": "1.36.0",
-        "constructs": "^3.0.2"
-      }
-    },
-    "@aws-cdk/aws-cognito": {
-      "version": "1.36.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cognito/-/aws-cognito-1.36.0.tgz",
-      "integrity": "sha512-c6WUm8wME3Nvai12Y2d5yiWOfuoL/93M0s5MTaSo5aKdroL2qrBPKPM1VsLImBbODkgROKzjnvGMlKo4G7vD2Q==",
-      "requires": {
-        "@aws-cdk/aws-certificatemanager": "1.36.0",
-        "@aws-cdk/aws-iam": "1.36.0",
-        "@aws-cdk/aws-lambda": "1.36.0",
-        "@aws-cdk/core": "1.36.0",
-        "@aws-cdk/custom-resources": "1.36.0",
-        "constructs": "^3.0.2"
-      }
-    },
-    "@aws-cdk/aws-ec2": {
-      "version": "1.36.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ec2/-/aws-ec2-1.36.0.tgz",
-      "integrity": "sha512-8PJwA0YMdMPGGWPe/LmOjwHhQ/OI2hy01dPzsybQk1Vt8pOif9qTCYvmYJD1F19m1o7NaxVJuxJ3hBcX4FRKZQ==",
-      "requires": {
-        "@aws-cdk/aws-cloudwatch": "1.36.0",
-        "@aws-cdk/aws-iam": "1.36.0",
-        "@aws-cdk/aws-logs": "1.36.0",
-        "@aws-cdk/aws-s3": "1.36.0",
-        "@aws-cdk/aws-ssm": "1.36.0",
-        "@aws-cdk/core": "1.36.0",
-        "@aws-cdk/cx-api": "1.36.0",
-        "@aws-cdk/region-info": "1.36.0",
-        "constructs": "^3.0.2"
-      }
-    },
-    "@aws-cdk/aws-elasticloadbalancing": {
-      "version": "1.36.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-elasticloadbalancing/-/aws-elasticloadbalancing-1.36.0.tgz",
-      "integrity": "sha512-DTGs8VmUH+nKL9pehde1+/kCyE+wfKcN50gl+7SM/N2D3/ASlHRU10DfxIBtJM1MoeC4HTpTizEVu91hzkCsew==",
-      "requires": {
-        "@aws-cdk/aws-ec2": "1.36.0",
-        "@aws-cdk/core": "1.36.0",
-        "constructs": "^3.0.2"
-      }
-    },
-    "@aws-cdk/aws-elasticloadbalancingv2": {
-      "version": "1.36.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-elasticloadbalancingv2/-/aws-elasticloadbalancingv2-1.36.0.tgz",
-      "integrity": "sha512-4WucnVyzH4SE4OvU0Vq9ca9pf+eFZz4F2D54dArohVMkwr4IvGEDmfhwB16iQye+yCdS6/f9W0MVn42kvgpeGA==",
-      "requires": {
-        "@aws-cdk/aws-certificatemanager": "1.36.0",
-        "@aws-cdk/aws-cloudwatch": "1.36.0",
-        "@aws-cdk/aws-ec2": "1.36.0",
-        "@aws-cdk/aws-iam": "1.36.0",
-        "@aws-cdk/aws-lambda": "1.36.0",
-        "@aws-cdk/aws-s3": "1.36.0",
-        "@aws-cdk/core": "1.36.0",
-        "constructs": "^3.0.2"
-      }
-    },
-    "@aws-cdk/aws-events": {
-      "version": "1.36.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-events/-/aws-events-1.36.0.tgz",
-      "integrity": "sha512-z1/TpM/UHoSf4yyvI/c8cXXy1fAu7hDN1YZJ7IB/dbIj1m1KuqpI5ymuSVaG+VJe+ZFR9k8KaL4cQOe8sJdA2w==",
-      "requires": {
-        "@aws-cdk/aws-iam": "1.36.0",
-        "@aws-cdk/core": "1.36.0",
-        "constructs": "^3.0.2"
-      }
-    },
-    "@aws-cdk/aws-iam": {
-      "version": "1.36.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-iam/-/aws-iam-1.36.0.tgz",
-      "integrity": "sha512-Upt34e8NFjfeqrYlNIZr/g8RXCv57z7BLxWt+z5HEfaBx3jfK0cK6+NX20JdJbVyl/ZQzfdMeK6bpcjyMBnpbQ==",
-      "requires": {
-        "@aws-cdk/core": "1.36.0",
-        "@aws-cdk/region-info": "1.36.0",
-        "constructs": "^3.0.2"
-      }
-    },
-    "@aws-cdk/aws-kms": {
-      "version": "1.36.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-kms/-/aws-kms-1.36.0.tgz",
-      "integrity": "sha512-kB66DkKhn5g4yXfrzpnCG7kMu2Yhm035nGmvj1Nsj4e7zwrSsaUXYcJNwQxU9H4s7xFJ9YZwYh922rQgOUOA6Q==",
-      "requires": {
-        "@aws-cdk/aws-iam": "1.36.0",
-        "@aws-cdk/core": "1.36.0",
-        "constructs": "^3.0.2"
-      }
-    },
-    "@aws-cdk/aws-lambda": {
-      "version": "1.36.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-lambda/-/aws-lambda-1.36.0.tgz",
-      "integrity": "sha512-YRVrj2ZI/xSHboOM2IzcwNO1o+vdgrpKlvNWC+4wq/QFLuM8ts99ilNI49uhOT8GaKOW5HjMPWgLvevvERGv8A==",
-      "requires": {
-        "@aws-cdk/aws-cloudwatch": "1.36.0",
-        "@aws-cdk/aws-ec2": "1.36.0",
-        "@aws-cdk/aws-events": "1.36.0",
-        "@aws-cdk/aws-iam": "1.36.0",
-        "@aws-cdk/aws-logs": "1.36.0",
-        "@aws-cdk/aws-s3": "1.36.0",
-        "@aws-cdk/aws-s3-assets": "1.36.0",
-        "@aws-cdk/aws-sqs": "1.36.0",
-        "@aws-cdk/core": "1.36.0",
-        "@aws-cdk/cx-api": "1.36.0",
-        "constructs": "^3.0.2"
-      }
-    },
-    "@aws-cdk/aws-logs": {
-      "version": "1.36.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-logs/-/aws-logs-1.36.0.tgz",
-      "integrity": "sha512-x4Y5ju+aHvNXuLWU8FsDKU+hT7+rRqZNjQtYyRfQr1W1ZtPiAICs6D8+kHKvqw/6bnbzWk4RYstlRfMylnRBwg==",
-      "requires": {
-        "@aws-cdk/aws-cloudwatch": "1.36.0",
-        "@aws-cdk/aws-iam": "1.36.0",
-        "@aws-cdk/core": "1.36.0",
-        "constructs": "^3.0.2"
-      }
-    },
-    "@aws-cdk/aws-route53": {
-      "version": "1.36.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-route53/-/aws-route53-1.36.0.tgz",
-      "integrity": "sha512-x2nfN6D54ozDtGIdIti8WCv5cBw1uesv2+AdlB3BUktekfwHEvzhUwca5JefgXvAq5WqQit6YnFaYjjzPKl1og==",
-      "requires": {
-        "@aws-cdk/aws-ec2": "1.36.0",
-        "@aws-cdk/aws-logs": "1.36.0",
-        "@aws-cdk/core": "1.36.0",
-        "@aws-cdk/cx-api": "1.36.0",
-        "constructs": "^3.0.2"
-      }
-    },
-    "@aws-cdk/aws-route53-patterns": {
-      "version": "1.36.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-route53-patterns/-/aws-route53-patterns-1.36.0.tgz",
-      "integrity": "sha512-IbWsTJtffivHRuh5KeO6w3aBu4uRYdr4aLQ7BkXEAnkpWl6nTI7GXkA8LiYc9lSS/23aiyQzOxLtBGmmJnmonw==",
-      "requires": {
-        "@aws-cdk/aws-certificatemanager": "1.36.0",
-        "@aws-cdk/aws-cloudfront": "1.36.0",
-        "@aws-cdk/aws-iam": "1.36.0",
-        "@aws-cdk/aws-route53": "1.36.0",
-        "@aws-cdk/aws-route53-targets": "1.36.0",
-        "@aws-cdk/aws-s3": "1.36.0",
-        "@aws-cdk/core": "1.36.0",
-        "@aws-cdk/region-info": "1.36.0",
-        "constructs": "^3.0.2"
-      }
-    },
-    "@aws-cdk/aws-route53-targets": {
-      "version": "1.36.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-route53-targets/-/aws-route53-targets-1.36.0.tgz",
-      "integrity": "sha512-8W1qCKC7DaDzG3ia2KI/EiiCbczh/DCTYcaewBqE32hBR/2JQIET+EOCdlPnlY3PUpdrH8vCsfuPp9O6cZrLuw==",
-      "requires": {
-        "@aws-cdk/aws-apigateway": "1.36.0",
-        "@aws-cdk/aws-cloudfront": "1.36.0",
-        "@aws-cdk/aws-cognito": "1.36.0",
-        "@aws-cdk/aws-ec2": "1.36.0",
-        "@aws-cdk/aws-elasticloadbalancing": "1.36.0",
-        "@aws-cdk/aws-elasticloadbalancingv2": "1.36.0",
-        "@aws-cdk/aws-iam": "1.36.0",
-        "@aws-cdk/aws-route53": "1.36.0",
-        "@aws-cdk/aws-s3": "1.36.0",
-        "@aws-cdk/core": "1.36.0",
-        "@aws-cdk/region-info": "1.36.0",
-        "constructs": "^3.0.2"
-      }
-    },
-    "@aws-cdk/aws-s3": {
-      "version": "1.36.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-s3/-/aws-s3-1.36.0.tgz",
-      "integrity": "sha512-4UCQ1W+n8f3/uIb2Hs/yrPtVDZHpmAAKJCI1JwPQ1aj4D/BJGqp7UJjoq1Oo3Po7TgjtuAIiyHEyghj2NAyg1g==",
-      "requires": {
-        "@aws-cdk/aws-events": "1.36.0",
-        "@aws-cdk/aws-iam": "1.36.0",
-        "@aws-cdk/aws-kms": "1.36.0",
-        "@aws-cdk/core": "1.36.0",
-        "constructs": "^3.0.2"
-      }
-    },
-    "@aws-cdk/aws-s3-assets": {
-      "version": "1.36.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-s3-assets/-/aws-s3-assets-1.36.0.tgz",
-      "integrity": "sha512-n6zTU8ePdGaIqwFvbVsXRNz4ug9SFOA8PAXV3YSI7Eh2AfwBQ+jG7H6hMcwTgEdv17/CXMptz1N7xY/tAkODWw==",
-      "requires": {
-        "@aws-cdk/assets": "1.36.0",
-        "@aws-cdk/aws-iam": "1.36.0",
-        "@aws-cdk/aws-s3": "1.36.0",
-        "@aws-cdk/core": "1.36.0",
-        "@aws-cdk/cx-api": "1.36.0",
-        "constructs": "^3.0.2"
-      }
-    },
-    "@aws-cdk/aws-s3-deployment": {
-      "version": "1.36.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-s3-deployment/-/aws-s3-deployment-1.36.0.tgz",
-      "integrity": "sha512-58pPF0GMLpZ/LZfC4e3cxL8+8/juDxMPpr/Mx2gKAd8TsOcqN+rr5G/JgCklEcIK5vOctI8RSBUSEHBL+nbf2Q==",
-      "requires": {
-        "@aws-cdk/aws-cloudformation": "1.36.0",
-        "@aws-cdk/aws-cloudfront": "1.36.0",
-        "@aws-cdk/aws-iam": "1.36.0",
-        "@aws-cdk/aws-lambda": "1.36.0",
-        "@aws-cdk/aws-s3": "1.36.0",
-        "@aws-cdk/aws-s3-assets": "1.36.0",
-        "@aws-cdk/core": "1.36.0",
-        "constructs": "^3.0.2"
-      }
-    },
-    "@aws-cdk/aws-sns": {
-      "version": "1.36.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-sns/-/aws-sns-1.36.0.tgz",
-      "integrity": "sha512-7CDG1+exvs3jv+0Qt5JM8QOFlcVPXPgMS2/2znayrmqooFOrcBH+99dlvNlonp76YkUSvbVSoMZzE2yyfNeAzQ==",
-      "requires": {
-        "@aws-cdk/aws-cloudwatch": "1.36.0",
-        "@aws-cdk/aws-events": "1.36.0",
-        "@aws-cdk/aws-iam": "1.36.0",
-        "@aws-cdk/aws-kms": "1.36.0",
-        "@aws-cdk/core": "1.36.0",
-        "constructs": "^3.0.2"
-      }
-    },
-    "@aws-cdk/aws-sqs": {
-      "version": "1.36.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-sqs/-/aws-sqs-1.36.0.tgz",
-      "integrity": "sha512-l2qodi/ivcwzw+cFIzjN9IvRmuAVKTSXvKBR25G/ubfccMuwS6qR3xAdR5Dbx98t/vaX+wKHRdS9KmF/5zSf2g==",
-      "requires": {
-        "@aws-cdk/aws-cloudwatch": "1.36.0",
-        "@aws-cdk/aws-iam": "1.36.0",
-        "@aws-cdk/aws-kms": "1.36.0",
-        "@aws-cdk/core": "1.36.0",
-        "constructs": "^3.0.2"
-      }
-    },
-    "@aws-cdk/aws-ssm": {
-      "version": "1.36.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ssm/-/aws-ssm-1.36.0.tgz",
-      "integrity": "sha512-eLTbVRXMTjLQzTMFWdDbDc8VFmET3+Vp3bSll6wLJ6oKbAmrPxSMT7Wn0xQAhnXh23OXaolOYnKSIxujI8fVOw==",
-      "requires": {
-        "@aws-cdk/aws-iam": "1.36.0",
-        "@aws-cdk/aws-kms": "1.36.0",
-        "@aws-cdk/core": "1.36.0",
-        "@aws-cdk/cx-api": "1.36.0",
-        "constructs": "^3.0.2"
-      }
-    },
-    "@aws-cdk/cfnspec": {
-      "version": "1.36.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cfnspec/-/cfnspec-1.36.0.tgz",
-      "integrity": "sha512-PxUuSjTFss6jgLIt6SVSUZWxoWmDuZ9x+xLNOlH8bBFPIk/gAaDbBduqRufe4Nlt+H+W3gczcvH4gotRhgLVFg==",
-      "dev": true,
-      "requires": {
-        "md5": "^2.2.1"
-      }
-    },
-    "@aws-cdk/cloud-assembly-schema": {
-      "version": "1.36.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-1.36.0.tgz",
-      "integrity": "sha512-MEWxUqnAbOL07gOB9ZSV2TLYcn678Ayu6qsKJ8iJI+OArjOcBRempWeWLMGZsf/aVbsQ6OMB6FU2kWZUERzN2g==",
-      "requires": {
-        "jsonschema": "^1.2.5",
-        "semver": "^7.2.2"
-      },
-      "dependencies": {
-        "jsonschema": {
-          "version": "1.2.6",
-          "bundled": true
-        },
-        "semver": {
-          "version": "7.3.2",
-          "bundled": true
-        }
-      }
-    },
-    "@aws-cdk/cloudformation-diff": {
-      "version": "1.36.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cloudformation-diff/-/cloudformation-diff-1.36.0.tgz",
-      "integrity": "sha512-G1AjREokyvoKxh6gBt4WYYq4CHt5gzZRTNkEgcuntf+B2VEeEZkhsxYY5UJUHRTxNemHivZuuzI2H7BePq7bgw==",
-      "dev": true,
-      "requires": {
-        "@aws-cdk/cfnspec": "1.36.0",
-        "colors": "^1.4.0",
-        "diff": "^4.0.2",
-        "fast-deep-equal": "^3.1.1",
-        "string-width": "^4.2.0",
-        "table": "^5.4.6"
-      },
-      "dependencies": {
-        "diff": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-          "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-          "dev": true
-        }
-      }
-    },
-    "@aws-cdk/core": {
-      "version": "1.36.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/core/-/core-1.36.0.tgz",
-      "integrity": "sha512-ElGFYI9sw4cgoNqeYh0o0leOj69eke0IfqjiI60D1nfexjRukKn/N5SQCoxaW3qTxXLmW6mk/7DZ/k0lm5RDbw==",
-      "requires": {
-        "@aws-cdk/cloud-assembly-schema": "1.36.0",
-        "@aws-cdk/cx-api": "1.36.0",
-        "constructs": "^3.0.2"
-      }
-    },
     "@aws-cdk/custom-resources": {
-      "version": "1.36.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/custom-resources/-/custom-resources-1.36.0.tgz",
-      "integrity": "sha512-5okqSjuBOuKzfrJ5RfHgNvRZ7sB3R+oQ7dqKb+G2SPHU4e0DyuvJ73jutc9mRSTgrkB8vWNaz9BbL4VmXLYH/w==",
+      "version": "1.45.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/custom-resources/-/custom-resources-1.45.0.tgz",
+      "integrity": "sha512-Du19BhdyOUqO6zF0Aw+wIGCVZhKzyH3i1Lq6Z7tqpw/DKo4wqH1od8EY3UG+/ebPxklX8wdbBRFbUVL/AHecHg==",
       "requires": {
-        "@aws-cdk/aws-cloudformation": "1.36.0",
-        "@aws-cdk/aws-iam": "1.36.0",
-        "@aws-cdk/aws-lambda": "1.36.0",
-        "@aws-cdk/aws-logs": "1.36.0",
-        "@aws-cdk/aws-sns": "1.36.0",
-        "@aws-cdk/core": "1.36.0",
+        "@aws-cdk/aws-cloudformation": "1.45.0",
+        "@aws-cdk/aws-iam": "1.45.0",
+        "@aws-cdk/aws-lambda": "1.45.0",
+        "@aws-cdk/aws-logs": "1.45.0",
+        "@aws-cdk/aws-sns": "1.45.0",
+        "@aws-cdk/core": "1.45.0",
         "constructs": "^3.0.2"
       }
     },
     "@aws-cdk/cx-api": {
-      "version": "1.36.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cx-api/-/cx-api-1.36.0.tgz",
-      "integrity": "sha512-TuKV7u2lOofK02i1Eh0zv2ODsweJdzgslFqYCabWnDX/ZRQyhEiGCP+zDmXAvD7a5Xo6pi1yGuwTuQPYW8eCHg==",
+      "version": "1.45.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cx-api/-/cx-api-1.45.0.tgz",
+      "integrity": "sha512-OQnG2tdnmX4D3LXDchNlzFjj7PhsLte6W/X0lOWhY3ysFZfMhOheB32oTRYLHyYBuRUTFGtOB1TmdT6N4MVQnA==",
       "requires": {
-        "@aws-cdk/cloud-assembly-schema": "1.36.0",
+        "@aws-cdk/cloud-assembly-schema": "1.45.0",
         "semver": "^7.2.2"
       },
       "dependencies": {
@@ -446,9 +465,9 @@
       }
     },
     "@aws-cdk/region-info": {
-      "version": "1.36.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/region-info/-/region-info-1.36.0.tgz",
-      "integrity": "sha512-aHFj+MUrtWHxNnAWh32vo+MJoLZ+z2plYreBxdPO/R5phu9pWaWyFzKfBJywaQLYRiMxL7tWEyUjvbQy6/MPqw=="
+      "version": "1.45.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/region-info/-/region-info-1.45.0.tgz",
+      "integrity": "sha512-kCI8od1ELYL06cEcyD13XH1fc0E5+j8JSpJAjcLriFqk+Vk7VUSsfogo1diqnyrrcApbMRvJMKSvFSmWfzYVCg=="
     },
     "@babel/code-frame": {
       "version": "7.5.5",
@@ -1133,23 +1152,23 @@
       "dev": true
     },
     "aws-cdk": {
-      "version": "1.36.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-1.36.0.tgz",
-      "integrity": "sha512-B+ffE8lhiWwuX+eiCtsSg7hwWK0aA6E6v9nh3RYwT/Bl2O6ya10+WSYfMlacrzx+iKPGFnQL5/SRnzBIDTmwrA==",
+      "version": "1.45.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-1.45.0.tgz",
+      "integrity": "sha512-Y/h11zpbwDYeDW8d/E04LRwPFnRAk2glxVnvXqsmvso+e1F1jTHRgIohVYVOudi2GwJJ5yddIgNh/Wjck6V4pg==",
       "dev": true,
       "requires": {
-        "@aws-cdk/cdk-assets-schema": "1.36.0",
-        "@aws-cdk/cloud-assembly-schema": "1.36.0",
-        "@aws-cdk/cloudformation-diff": "1.36.0",
-        "@aws-cdk/cx-api": "1.36.0",
-        "@aws-cdk/region-info": "1.36.0",
+        "@aws-cdk/cdk-assets-schema": "1.45.0",
+        "@aws-cdk/cloud-assembly-schema": "1.45.0",
+        "@aws-cdk/cloudformation-diff": "1.45.0",
+        "@aws-cdk/cx-api": "1.45.0",
+        "@aws-cdk/region-info": "1.45.0",
         "archiver": "^4.0.1",
-        "aws-sdk": "^2.663.0",
+        "aws-sdk": "^2.691.0",
         "camelcase": "^6.0.0",
-        "cdk-assets": "1.36.0",
+        "cdk-assets": "1.45.0",
         "colors": "^1.4.0",
         "decamelize": "^4.0.0",
-        "fs-extra": "^8.1.0",
+        "fs-extra": "^9.0.1",
         "glob": "^7.1.6",
         "json-diff": "^0.5.4",
         "minimatch": ">=3.0",
@@ -1158,33 +1177,33 @@
         "semver": "^7.2.2",
         "source-map-support": "^0.5.19",
         "table": "^5.4.6",
-        "uuid": "^7.0.3",
-        "yaml": "^1.9.2",
+        "uuid": "^8.1.0",
+        "yaml": "^1.10.0",
         "yargs": "^15.3.1"
       },
       "dependencies": {
         "@aws-cdk/cdk-assets-schema": {
-          "version": "1.36.0",
-          "resolved": "https://registry.npmjs.org/@aws-cdk/cdk-assets-schema/-/cdk-assets-schema-1.36.0.tgz",
-          "integrity": "sha512-sI8Bc2KobWcAwh1EzhUY0TSWIAQByxGjXZgW6rAZ6EKllttXXUmTATCTHDNVzHyvCbBbmRs69oDomWAm5C5MyQ==",
+          "version": "1.45.0",
+          "resolved": "https://registry.npmjs.org/@aws-cdk/cdk-assets-schema/-/cdk-assets-schema-1.45.0.tgz",
+          "integrity": "sha512-HvS9IN0RTIwJvldOLj/0FsWSj1h3jqeT9sfNdAW0g7FeFSPu3QtdYeDcSGrOo/4fPXsRFV4bcMqoEEph3x9MgQ==",
           "dev": true,
           "requires": {
             "semver": "^7.2.2"
           }
         },
         "@aws-cdk/cfnspec": {
-          "version": "1.36.0",
-          "resolved": "https://registry.npmjs.org/@aws-cdk/cfnspec/-/cfnspec-1.36.0.tgz",
-          "integrity": "sha512-PxUuSjTFss6jgLIt6SVSUZWxoWmDuZ9x+xLNOlH8bBFPIk/gAaDbBduqRufe4Nlt+H+W3gczcvH4gotRhgLVFg==",
+          "version": "1.45.0",
+          "resolved": "https://registry.npmjs.org/@aws-cdk/cfnspec/-/cfnspec-1.45.0.tgz",
+          "integrity": "sha512-Ps4P+e9xbqJkmlyREESN18jBUPixvaCdAyw6eNvfmQGQudFkggm05jiKMulLu/trzTdRuD8NBPE7pxZPgoOvIg==",
           "dev": true,
           "requires": {
             "md5": "^2.2.1"
           }
         },
         "@aws-cdk/cloud-assembly-schema": {
-          "version": "1.36.0",
-          "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-1.36.0.tgz",
-          "integrity": "sha512-MEWxUqnAbOL07gOB9ZSV2TLYcn678Ayu6qsKJ8iJI+OArjOcBRempWeWLMGZsf/aVbsQ6OMB6FU2kWZUERzN2g==",
+          "version": "1.45.0",
+          "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-1.45.0.tgz",
+          "integrity": "sha512-MoQ8580BJYDKzWHNPbn/WiB82A1JdZJXkZ/W0mwR6mi37DOJ6jbycyhGXA9aARw5iNIxqTEAXqGifrUI1ILG+w==",
           "dev": true,
           "requires": {
             "jsonschema": "^1.2.5",
@@ -1192,43 +1211,34 @@
           }
         },
         "@aws-cdk/cloudformation-diff": {
-          "version": "1.36.0",
-          "resolved": "https://registry.npmjs.org/@aws-cdk/cloudformation-diff/-/cloudformation-diff-1.36.0.tgz",
-          "integrity": "sha512-G1AjREokyvoKxh6gBt4WYYq4CHt5gzZRTNkEgcuntf+B2VEeEZkhsxYY5UJUHRTxNemHivZuuzI2H7BePq7bgw==",
+          "version": "1.45.0",
+          "resolved": "https://registry.npmjs.org/@aws-cdk/cloudformation-diff/-/cloudformation-diff-1.45.0.tgz",
+          "integrity": "sha512-/5djWhNdhoLz+zFDa8ALd83hqxu0KLKaDVp3NQvVF5FAS7GTrR4UlsSrOllI5DqWafF1pCIgM6LXGF95LoMmbg==",
           "dev": true,
           "requires": {
-            "@aws-cdk/cfnspec": "1.36.0",
+            "@aws-cdk/cfnspec": "1.45.0",
             "colors": "^1.4.0",
             "diff": "^4.0.2",
-            "fast-deep-equal": "^3.1.1",
+            "fast-deep-equal": "^3.1.3",
             "string-width": "^4.2.0",
             "table": "^5.4.6"
           }
         },
         "@aws-cdk/cx-api": {
-          "version": "1.36.0",
-          "resolved": "https://registry.npmjs.org/@aws-cdk/cx-api/-/cx-api-1.36.0.tgz",
-          "integrity": "sha512-TuKV7u2lOofK02i1Eh0zv2ODsweJdzgslFqYCabWnDX/ZRQyhEiGCP+zDmXAvD7a5Xo6pi1yGuwTuQPYW8eCHg==",
+          "version": "1.45.0",
+          "resolved": "https://registry.npmjs.org/@aws-cdk/cx-api/-/cx-api-1.45.0.tgz",
+          "integrity": "sha512-OQnG2tdnmX4D3LXDchNlzFjj7PhsLte6W/X0lOWhY3ysFZfMhOheB32oTRYLHyYBuRUTFGtOB1TmdT6N4MVQnA==",
           "dev": true,
           "requires": {
-            "@aws-cdk/cloud-assembly-schema": "1.36.0",
+            "@aws-cdk/cloud-assembly-schema": "1.45.0",
             "semver": "^7.2.2"
           }
         },
         "@aws-cdk/region-info": {
-          "version": "1.36.0",
-          "resolved": "https://registry.npmjs.org/@aws-cdk/region-info/-/region-info-1.36.0.tgz",
-          "integrity": "sha512-aHFj+MUrtWHxNnAWh32vo+MJoLZ+z2plYreBxdPO/R5phu9pWaWyFzKfBJywaQLYRiMxL7tWEyUjvbQy6/MPqw==",
+          "version": "1.45.0",
+          "resolved": "https://registry.npmjs.org/@aws-cdk/region-info/-/region-info-1.45.0.tgz",
+          "integrity": "sha512-kCI8od1ELYL06cEcyD13XH1fc0E5+j8JSpJAjcLriFqk+Vk7VUSsfogo1diqnyrrcApbMRvJMKSvFSmWfzYVCg==",
           "dev": true
-        },
-        "@babel/runtime": {
-          "version": "7.9.2",
-          "resolved": "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.9.2.tgz#d90df0583a3a252f09aaa619665367bae518db06",
-          "integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
-          "dev": true,
-          "requires": {
-            "regenerator-runtime": "^0.13.4"
-          }
         },
         "@types/color-name": {
           "version": "1.1.1",
@@ -1354,13 +1364,19 @@
             "lodash": "^4.17.14"
           }
         },
+        "at-least-node": {
+          "version": "1.0.0",
+          "resolved": "https://registry.yarnpkg.com/at-least-node/-/at-least-node-1.0.0.tgz#602cd4b46e844ad4effc92a8011a3c46e0238dc2",
+          "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
+          "dev": true
+        },
         "aws-sdk": {
-          "version": "2.663.0",
-          "resolved": "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.663.0.tgz#003d8cc318635d1bf67deda586f5e5d583b7e384",
-          "integrity": "sha512-xPOszNOaSXTRs8VGXaMbhTKXdlq2TlDRfFRVEGxkZrtow87hEIVZGAUSUme2e3GHqHUDnySwcufrUpUPUizOKQ==",
+          "version": "2.691.0",
+          "resolved": "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.691.0.tgz#92361b63117e94d065dad2f215296f5a19fe0c70",
+          "integrity": "sha512-HV/iANH5PJvexubWr/oDmWMKtV/n1shtrACrLIUa5vTXIT6O7CzUouExNOvOtFMZw8zJkLmyEpa/0bDpMmo0Zg==",
           "dev": true,
           "requires": {
-            "buffer": "4.9.1",
+            "buffer": "4.9.2",
             "events": "1.1.1",
             "ieee754": "1.1.13",
             "jmespath": "0.15.0",
@@ -1372,9 +1388,9 @@
           },
           "dependencies": {
             "buffer": {
-              "version": "4.9.1",
-              "resolved": "https://registry.yarnpkg.com/buffer/-/buffer-4.9.1.tgz#6d1bb601b07a4efced97094132093027c95bc298",
-              "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
+              "version": "4.9.2",
+              "resolved": "https://registry.yarnpkg.com/buffer/-/buffer-4.9.2.tgz#230ead344002988644841ab0244af8c44bbe3ef8",
+              "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
               "dev": true,
               "requires": {
                 "base64-js": "^1.0.2",
@@ -1486,14 +1502,15 @@
           "dev": true
         },
         "cdk-assets": {
-          "version": "1.36.0",
-          "resolved": "https://registry.npmjs.org/cdk-assets/-/cdk-assets-1.36.0.tgz",
-          "integrity": "sha512-NuwP3OIexrsElfxXuZN01wijZeVFLhZKV59kzsCmZ51j9vyEEwuSPvXgryqwrpi2gkWivcz/YVs/mXq3AcYN/A==",
+          "version": "1.45.0",
+          "resolved": "https://registry.npmjs.org/cdk-assets/-/cdk-assets-1.45.0.tgz",
+          "integrity": "sha512-8bCxDDQsWeGq9o1MNLhcY/3Ke7psLA3Zp6jmvw3qYCqGyJg1nzQs8VKoSY6Faj65KzXcJDS3cmVXJJvRJvJgWQ==",
           "dev": true,
           "requires": {
-            "@aws-cdk/cdk-assets-schema": "1.36.0",
+            "@aws-cdk/cdk-assets-schema": "1.45.0",
+            "@aws-cdk/cx-api": "1.45.0",
             "archiver": "^4.0.1",
-            "aws-sdk": "^2.663.0",
+            "aws-sdk": "^2.691.0",
             "glob": "^7.1.6",
             "yargs": "^15.3.1"
           }
@@ -1784,9 +1801,9 @@
           "dev": true
         },
         "fast-deep-equal": {
-          "version": "3.1.1",
-          "resolved": "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz#545145077c501491e33b15ec408c294376e94ae4",
-          "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==",
+          "version": "3.1.3",
+          "resolved": "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525",
+          "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
           "dev": true
         },
         "fast-json-stable-stringify": {
@@ -1824,14 +1841,15 @@
           "dev": true
         },
         "fs-extra": {
-          "version": "8.1.0",
-          "resolved": "https://registry.yarnpkg.com/fs-extra/-/fs-extra-8.1.0.tgz#49d43c45a88cd9677668cb7be1b46efdb8d2e1c0",
-          "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+          "version": "9.0.1",
+          "resolved": "https://registry.yarnpkg.com/fs-extra/-/fs-extra-9.0.1.tgz#910da0062437ba4c39fedd863f1675ccfefcb9fc",
+          "integrity": "sha512-h2iAoN838FqAFJY2/qVpzFXy+EBxfVE220PalAqQLDVsFOHLJrZvut5puAbCdNv6WJk+B8ihI+k0c7JK5erwqQ==",
           "dev": true,
           "requires": {
+            "at-least-node": "^1.0.0",
             "graceful-fs": "^4.2.0",
-            "jsonfile": "^4.0.0",
-            "universalify": "^0.1.0"
+            "jsonfile": "^6.0.1",
+            "universalify": "^1.0.0"
           }
         },
         "fs.realpath": {
@@ -1928,9 +1946,9 @@
           }
         },
         "graceful-fs": {
-          "version": "4.2.3",
-          "resolved": "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.3.tgz#4a12ff1b60376ef09862c2093edd908328be8423",
-          "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
+          "version": "4.2.4",
+          "resolved": "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.4.tgz#2256bde14d3632958c465ebc96dc467ca07a29fb",
+          "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
           "dev": true
         },
         "heap": {
@@ -2079,12 +2097,13 @@
           "dev": true
         },
         "jsonfile": {
-          "version": "4.0.0",
-          "resolved": "https://registry.yarnpkg.com/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb",
-          "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+          "version": "6.0.1",
+          "resolved": "https://registry.yarnpkg.com/jsonfile/-/jsonfile-6.0.1.tgz#98966cba214378c8c84b82e085907b40bf614179",
+          "integrity": "sha512-jR2b5v7d2vIOust+w3wtFKZIfpC2pnRmFAhAC/BuweZFQR8qZzxH1OyrQ10HmdVYiXWkYUqPVsz91cG7EL2FBg==",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.6"
+            "graceful-fs": "^4.1.6",
+            "universalify": "^1.0.0"
           }
         },
         "jsonschema": {
@@ -2396,12 +2415,6 @@
             "util-deprecate": "~1.0.1"
           }
         },
-        "regenerator-runtime": {
-          "version": "0.13.5",
-          "resolved": "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz#d878a1d094b4306d10b9096484b33ebd55e26697",
-          "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA==",
-          "dev": true
-        },
         "require-directory": {
           "version": "2.1.1",
           "resolved": "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42",
@@ -2672,9 +2685,9 @@
           }
         },
         "universalify": {
-          "version": "0.1.2",
-          "resolved": "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66",
-          "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+          "version": "1.0.0",
+          "resolved": "https://registry.yarnpkg.com/universalify/-/universalify-1.0.0.tgz#b61a1da173e8435b2fe3c67d29b9adf8594bd16d",
+          "integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==",
           "dev": true
         },
         "unpipe": {
@@ -2717,9 +2730,9 @@
           "dev": true
         },
         "uuid": {
-          "version": "7.0.3",
-          "resolved": "https://registry.yarnpkg.com/uuid/-/uuid-7.0.3.tgz#c5c9f2c8cf25dc0a372c4df1441c41f5bd0c680b",
-          "integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==",
+          "version": "8.1.0",
+          "resolved": "https://registry.yarnpkg.com/uuid/-/uuid-8.1.0.tgz#6f1536eb43249f473abc6bd58ff983da1ca30d8d",
+          "integrity": "sha512-CI18flHDznR0lq54xBycOVmphdCYnQLKn8abKn7PXUiKUGdEd+/l9LWNJmugXel4hXq7S+RMNl34ecyC9TntWg==",
           "dev": true
         },
         "which-module": {
@@ -2827,13 +2840,10 @@
           "dev": true
         },
         "yaml": {
-          "version": "1.9.2",
-          "resolved": "https://registry.yarnpkg.com/yaml/-/yaml-1.9.2.tgz#f0cfa865f003ab707663e4f04b3956957ea564ed",
-          "integrity": "sha512-HPT7cGGI0DuRcsO51qC1j9O16Dh1mZ2bnXwsi0jrSpsLz0WxOLSLXfkABVl6bZO629py3CU+OMJtpNHDLB97kg==",
-          "dev": true,
-          "requires": {
-            "@babel/runtime": "^7.9.2"
-          }
+          "version": "1.10.0",
+          "resolved": "https://registry.yarnpkg.com/yaml/-/yaml-1.10.0.tgz#3b593add944876077d4d683fee01081bd9fff31e",
+          "integrity": "sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg==",
+          "dev": true
         },
         "yargs": {
           "version": "15.3.1",
@@ -3393,9 +3403,9 @@
       "dev": true
     },
     "constructs": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.0.2.tgz",
-      "integrity": "sha512-Q4SkOFaRH2D65kvcGrDZ/FgJwk59HwUohbdCbeIueas+8RJhd9N4j6QgvHnMfTOmQWDPXCn1IGwteTLC0OK1NA=="
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.0.3.tgz",
+      "integrity": "sha512-JrYLpTlz92Un1jxkwoGiOiGoDjzIWtxo64sLC5FD4mQN1H9mAqZNvgxWYWaJIiWUXNkl5L5sO3GFf6peTj7UMQ=="
     },
     "convert-source-map": {
       "version": "1.7.0",
@@ -3940,9 +3950,9 @@
       "dev": true
     },
     "fast-deep-equal": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
-      "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true
     },
     "fast-json-stable-stringify": {

--- a/test/cdk-spa-deploy.test.ts
+++ b/test/cdk-spa-deploy.test.ts
@@ -51,7 +51,11 @@ test('Cloudfront Distribution Included', () => {
       PolicyDocument: {
           Statement: [
             {
-              "Action": "s3:GetObject",
+              "Action": [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*"
+              ],
               "Effect": "Allow",
               "Principal": {
                 "CanonicalUser": {
@@ -61,20 +65,28 @@ test('Cloudfront Distribution Included', () => {
                   ]
                 }
               },
-              "Resource": {
-                "Fn::Join": [
-                  "",
-                  [
-                    {
-                      "Fn::GetAtt": [
-                        "spaDeployWebsiteBucket1E4C4442",
-                        "Arn"
-                      ]
-                    },
-                    "/*"
+              "Resource": [
+                {
+                  "Fn::GetAtt": [
+                    "spaDeployWebsiteBucket1E4C4442",
+                    "Arn"
                   ]
-                ]
-              }
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Fn::GetAtt": [
+                          "spaDeployWebsiteBucket1E4C4442",
+                          "Arn"
+                        ]
+                      },
+                      "/*"
+                    ]
+                  ]
+                }
+              ]
             }]
       }
 }));
@@ -131,7 +143,11 @@ test('Cloudfront Distribution Included - with non-default error-doc cfg set', ()
           PolicyDocument: {
               Statement: [
                 {
-                  "Action": "s3:GetObject",
+                  "Action": [
+                    "s3:GetObject*",
+                    "s3:GetBucket*",
+                    "s3:List*"
+                  ],
                   "Effect": "Allow",
                   "Principal": {
                     "CanonicalUser": {
@@ -141,20 +157,28 @@ test('Cloudfront Distribution Included - with non-default error-doc cfg set', ()
                       ]
                     }
                   },
-                  "Resource": {
-                    "Fn::Join": [
-                      "",
-                      [
-                        {
-                          "Fn::GetAtt": [
-                            "spaDeployWebsiteBucket1E4C4442",
-                            "Arn"
-                          ]
-                        },
-                        "/*"
+                  "Resource": [
+                    {
+                      "Fn::GetAtt": [
+                        "spaDeployWebsiteBucket1E4C4442",
+                        "Arn"
                       ]
-                    ]
-                  }
+                    },
+                    {
+                      "Fn::Join": [
+                        "",
+                        [
+                          {
+                            "Fn::GetAtt": [
+                              "spaDeployWebsiteBucket1E4C4442",
+                              "Arn"
+                            ]
+                          },
+                          "/*"
+                        ]
+                      ]
+                    }
+                  ]
                 }]
           }
   }));
@@ -439,7 +463,11 @@ test('Create From Hosted Zone', () => {
       PolicyDocument: {
           Statement: [
             {
-              "Action": "s3:GetObject",
+              "Action": [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*"
+              ],
               "Effect": "Allow",
               "Principal": {
                 "CanonicalUser": {
@@ -449,20 +477,28 @@ test('Create From Hosted Zone', () => {
                   ]
                 }
               },
-              "Resource": {
-                "Fn::Join": [
-                  "",
-                  [
-                    {
-                      "Fn::GetAtt": [
-                        "spaDeployWebsiteBucket1E4C4442",
-                        "Arn"
-                      ]
-                    },
-                    "/*"
+              "Resource": [
+                {
+                  "Fn::GetAtt": [
+                    "spaDeployWebsiteBucket1E4C4442",
+                    "Arn"
                   ]
-                ]
-              }
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Fn::GetAtt": [
+                          "spaDeployWebsiteBucket1E4C4442",
+                          "Arn"
+                        ]
+                      },
+                      "/*"
+                    ]
+                  ]
+                }
+              ]
             }]
       }
 }));


### PR DESCRIPTION
The IP filter parameter does not have any use when applied to CloudFront distributions, aside from exposing the backing bucket to additional resources to additional consumers - happy to discuss maybe this is an intentional choice?

As per recommended practices, an origin access identity should be used instead to grant the CF dist access to the S3 origin.

In this change I've added a access identity to the distribution, and associated it to the bucket via a policy, this will allow the CloudFront distribution to read files from the bucket as required.

https://www.cloudconformity.com/knowledge-base/aws/CloudFront/s3-origin.html

https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-restricting-access-to-s3.html