### PR TITLE
Allow for a custom role to be passed in to the bucket deployment

### DIFF
--- a/lib/spa-deploy/spa-deploy-construct.ts
+++ b/lib/spa-deploy/spa-deploy-construct.ts
@@ -6,7 +6,7 @@ import {
   SSLMethod,
   SecurityPolicyProtocol,
 } from '@aws-cdk/aws-cloudfront';
-import { PolicyStatement } from '@aws-cdk/aws-iam';
+import { PolicyStatement, Role } from '@aws-cdk/aws-iam';
 import { HostedZone, ARecord, RecordTarget } from '@aws-cdk/aws-route53';
 import { DnsValidatedCertificate } from '@aws-cdk/aws-certificatemanager';
 import { HttpsRedirect } from '@aws-cdk/aws-route53-patterns';
@@ -27,6 +27,7 @@ export interface SPADeployConfig {
   readonly blockPublicAccess?:s3.BlockPublicAccess
   readonly sslMethod?: SSLMethod,
   readonly securityPolicy?: SecurityPolicyProtocol,
+  readonly role?:Role,
 }
 
 export interface HostedZoneConfig {
@@ -36,12 +37,14 @@ export interface HostedZoneConfig {
   readonly websiteFolder: string,
   readonly zoneName: string,
   readonly subdomain?: string,
+  readonly role?: Role,
 }
 
 export interface SPAGlobalConfig {
   readonly encryptBucket?:boolean,
   readonly ipFilter?:boolean,
-  readonly ipList?:string[]
+  readonly ipList?:string[],
+  readonly role?:Role,
 }
 
 export interface SPADeployment {
@@ -168,6 +171,7 @@ export class SPADeploy extends cdk.Construct {
 
       new s3deploy.BucketDeployment(this, 'BucketDeployment', {
         sources: [s3deploy.Source.asset(config.websiteFolder)],
+        role: config.role,
         destinationBucket: websiteBucket,
       });
 
@@ -203,6 +207,7 @@ export class SPADeploy extends cdk.Construct {
         // Invalidate the cache for / and index.html when we deploy so that cloudfront serves latest site
         distribution,
         distributionPaths: ['/', `/${config.indexDoc}`],
+        role: config.role,
       });
 
       new cdk.CfnOutput(this, 'cloudfront domain', {
@@ -235,6 +240,7 @@ export class SPADeploy extends cdk.Construct {
         destinationBucket: websiteBucket,
         // Invalidate the cache for / and index.html when we deploy so that cloudfront serves latest site
         distribution,
+        role: config.role,
         distributionPaths: ['/', `/${config.indexDoc}`],
       });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cdk-spa-deploy",
-  "version": "1.103.1",
+  "version": "1.103.2",
   "description": "This is an AWS CDK Construct to make deploying a single page website (Angular/React/Vue) to AWS S3 behind SSL/Cloudfront as easy as 5 lines of code.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/test/cdk-spa-deploy.test.ts
+++ b/test/cdk-spa-deploy.test.ts
@@ -273,6 +273,32 @@ test('Basic Site Setup with Custom Role', () => {
 });
 
 
+test('Basic Site Setup with Undefined Role', () => {
+  const stack = new Stack();
+
+  // WHEN
+  const deploy = new SPADeploy(stack, 'spaDeploy');
+
+  deploy.createBasicSite({
+    indexDoc: 'index.html',
+    errorDoc: 'error.html',
+    websiteFolder: 'website',
+    role: undefined
+  });
+
+  // THEN
+  expectCDK(stack).to(haveResource('AWS::Lambda::Function', {
+    Runtime: "python3.6",
+    Role: {
+      "Fn::GetAtt": [
+        "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRole89A01265",
+        "Arn"
+      ]
+    }
+  }));
+});
+
+
 test('Basic Site Setup, Encrypted Bucket', () => {
   const stack = new Stack();
 


### PR DESCRIPTION
This addition will allow for a custom role to be passed into the deployment lambda if a consumer wishes to do so, the consumer will need to ensure the appropriate permissions are granted, as AWS CDK will not "populate" those permissions for the,