### PR TITLE
Grant role explicit access to bucket via bucket policy

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cdk-spa-deploy",
-  "version": "1.104.0",
+  "version": "1.104.1",
   "description": "This is an AWS CDK Construct to make deploying a single page website (Angular/React/Vue) to AWS S3 behind SSL/Cloudfront as easy as 5 lines of code.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/test/cdk-spa-deploy.test.ts
+++ b/test/cdk-spa-deploy.test.ts
@@ -270,6 +270,34 @@ test('Basic Site Setup with Custom Role', () => {
       ]
     }
   }));
+  
+  expectCDK(stack).to(haveResourceLike('AWS::S3::BucketPolicy', {
+    PolicyDocument: {
+      Statement: [
+        {
+          Action: [
+            "s3:GetObject*",
+            "s3:GetBucket*",
+            "s3:List*",
+            "s3:DeleteObject*",
+            "s3:PutObject*",
+            "s3:Abort*"
+          ],
+          Condition: {
+            StringEquals: {
+              "aws:PrincipalArn": {
+                "Fn::GetAtt": [
+                  "myRoleE60D68E8",
+                  "Arn"
+                ]
+              }
+            }
+          },
+          Effect: 'Allow',
+          Principal: '*',
+        }],
+    },
+  }));
 });
 
 


### PR DESCRIPTION
For customers leveraging permission boundaries, they may need to "override" the settings of the permission boundary by setting an explicit allow in their bucket policy

The role's statements on their own are fine in the context of having no PB.

Ref: https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_evaluation-logic.html