### PR TITLE
fix #245: make `distributionPaths` configurable

### DIFF
--- a/lib/spa-deploy/spa-deploy-construct.ts
+++ b/lib/spa-deploy/spa-deploy-construct.ts
@@ -23,6 +23,7 @@ export interface SPADeployConfig {
   readonly certificateARN?: string,
   readonly cfBehaviors?: Behavior[],
   readonly cfAliases?: string[],
+  readonly distributionPaths?: string[],
   readonly exportWebsiteUrlOutput?:boolean,
   readonly exportWebsiteUrlName?: string,
   readonly blockPublicAccess?:s3.BlockPublicAccess
@@ -235,7 +236,7 @@ export class SPADeploy extends Construct {
         destinationBucket: websiteBucket,
         // Invalidate the cache for / and index.html when we deploy so that cloudfront serves latest site
         distribution,
-        distributionPaths: ['/', `/${config.indexDoc}`],
+        distributionPaths: config.distributionPaths || ['/', `/${config.indexDoc}`],
         role: config.role,
       });
 

--- a/lib/spa-deploy/spa-deploy-construct.ts
+++ b/lib/spa-deploy/spa-deploy-construct.ts
@@ -36,6 +36,7 @@ export interface HostedZoneConfig {
   readonly indexDoc:string,
   readonly errorDoc?:string,
   readonly cfBehaviors?: Behavior[],
+  readonly distributionPaths?: string[],
   readonly websiteFolder: string,
   readonly zoneName: string,
   readonly subdomain?: string,
@@ -271,7 +272,7 @@ export class SPADeploy extends Construct {
         // Invalidate the cache for / and index.html when we deploy so that cloudfront serves latest site
         distribution,
         role: config.role,
-        distributionPaths: ['/', `/${config.indexDoc}`],
+        distributionPaths: config.distributionPaths || ['/', `/${config.indexDoc}`],
       });
 
       new ARecord(this, 'Alias', {

--- a/test/cdk-spa-deploy.test.ts
+++ b/test/cdk-spa-deploy.test.ts
@@ -518,6 +518,27 @@ test('Cloudfront With Custom Defined Behaviors', () => {
   }));
 });
 
+test('Cloudfront With Custom Distribution Paths', () => {
+  const stack = new Stack();
+  // WHEN
+  const deploy = new SPADeploy(stack, 'spaDeploy');
+
+  deploy.createSiteWithCloudfront({
+    indexDoc: 'index.html',
+    websiteFolder: 'website',
+    certificateARN: 'arn:1234',
+    cfAliases: ['www.test.com'],
+    distributionPaths: ['/images/*.png'],
+  });
+
+  const template = Template.fromStack(stack);
+
+  // THEN
+  template.hasResourceProperties('Custom::CDKBucketDeployment', {
+      DistributionPaths: ['/images/*.png']
+  });
+});
+
 test('Cloudfront With Custom Security Policy', () => {
   const stack = new Stack();
   // WHEN

--- a/test/cdk-spa-deploy.test.ts
+++ b/test/cdk-spa-deploy.test.ts
@@ -778,6 +778,31 @@ test('Create From Hosted Zone with Custom Role', () => {
   }));
 });
 
+test('Create From Hosted Zone with Custom Distribution Paths', () => {
+  const app = new App();
+  const stack = new Stack(app, 'testStack', {
+    env: {
+      region: 'us-east-1',
+      account: '1234',
+    },
+  });
+  // WHEN
+  new SPADeploy(stack, 'spaDeploy', { encryptBucket: true })
+    .createSiteFromHostedZone({
+      zoneName: 'cdkspadeploy.com',
+      indexDoc: 'index.html',
+      websiteFolder: 'website',
+      distributionPaths: ['/images/*.png'],
+    });
+
+  const template = Template.fromStack(stack);
+
+  // THEN  
+  template.hasResourceProperties('Custom::CDKBucketDeployment', {
+      DistributionPaths: ['/images/*.png']
+  });
+});
+
 test('Create From Hosted Zone with Error Bucket', () => {
   const app = new App();
   const stack = new Stack(app, 'testStack', {


### PR DESCRIPTION
I added a test with `distributionPaths: ['/images/*.png']`, like the example in the [CDK docs](https://docs.aws.amazon.com/cdk/api/v1/docs/aws-s3-deployment-readme.html#cloudfront-invalidation).